### PR TITLE
Documentar novo sistema de api

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -170,6 +170,11 @@
           "pages": ["/self-hosting/guides/appstore-and-integration/syncing-third-party-apps"]
         },
         {
+          "group": "API",
+          "icon": "brackets-curly",
+          "pages": ["/self-hosting/guides/api/using-api-v2"]
+        },
+        {
           "group": "White Labeling",
           "icon": "tag",
           "pages": [

--- a/docs/self-hosting/guides/api/using-api-v2.mdx
+++ b/docs/self-hosting/guides/api/using-api-v2.mdx
@@ -1,0 +1,117 @@
+---
+title: "Using API v2 in Self-Hosted (OSS)"
+description: "How to use Cal.com API v2 when running the OSS/self-hosted stack"
+---
+
+## Overview
+
+This guide explains how to call the new API v2 when running the OSS/self-hosted stack. It covers base URLs, auth methods, versioning, pagination, and local development notes.
+
+## Base URL
+
+- Production (Cal.com Cloud): `https://api.cal.com`
+- Self-hosted default (local): `http://localhost:3003`
+
+Your environment may proxy the API behind your own domain. If you expose the API publicly, we recommend placing it behind HTTPS with a reverse proxy and using `https://<your-domain>` as the base.
+
+## Authentication
+
+API v2 supports three auth methods. Choose based on your use case:
+
+1) API Key (simple, per-tenant)
+- Where: App Dashboard → Settings → Security → API Keys
+- Header:
+
+```
+Authorization: Bearer <YOUR_API_KEY>
+```
+
+2) Platform OAuth Client Credentials (for platform endpoints/managed users/teams)
+- Headers:
+
+```
+x-cal-client-id: <OAUTH_CLIENT_ID>
+x-cal-secret-key: <OAUTH_CLIENT_SECRET>
+```
+
+3) Managed User Access Token (act on behalf of a managed user)
+- Header:
+
+```
+Authorization: Bearer <MANAGED_USER_ACCESS_TOKEN>
+```
+
+Access tokens are short-lived; refresh as needed using the OAuth refresh endpoints.
+
+## API Versioning
+
+Some endpoints accept an explicit version via header:
+
+```
+cal-api-version: 2024-09-04
+```
+
+Use the latest supported version from the API reference if your integration requires specific response shapes.
+
+## Pagination
+
+Most list endpoints support skip/take or limit/offset. Typical parameters:
+
+- `take` (default up to 250)
+- `skip` (default 0)
+
+Responses include pagination metadata (e.g., `totalItems`, `remainingItems`, `returnedItems`, `itemsPerPage`, `currentPage`, `totalPages`, `hasNextPage`, `hasPreviousPage`).
+
+## Errors
+
+Errors use standard HTTP status codes and JSON bodies. Common error identifiers include:
+
+- `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `UNPROCESSABLE_ENTITY`
+- `INVALID_PARAMETER`, `MISSING_PARAMETER`, `INVALID_API_KEY`, `RESOURCE_NOT_FOUND`, `DUPLICATE_RESOURCE`
+
+## Examples
+
+### Example: Get Webhooks (API Key)
+
+Request:
+
+```bash
+curl -X GET \
+  "http://localhost:3003/v2/webhooks" \
+  -H "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+### Example: Create Managed User (Platform OAuth)
+
+```bash
+curl -X POST \
+  "http://localhost:3003/v2/oauth-clients/<clientId>/users" \
+  -H "x-cal-client-id: <OAUTH_CLIENT_ID>" \
+  -H "x-cal-secret-key: <OAUTH_CLIENT_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "demo-user",
+    "email": "demo@example.com"
+  }'
+```
+
+### Example: Use Managed User Access Token
+
+```bash
+curl -X GET \
+  "http://localhost:3003/v2/bookings" \
+  -H "Authorization: Bearer <MANAGED_USER_ACCESS_TOKEN>"
+```
+
+## Local Development Tips
+
+- Start the web app and create API keys at `/settings/developer/api-keys`.
+- Start the API server with your workspace scripts (by default it listens on port 3003).
+- For browser testing, ensure CORS is configured if calling from a different origin.
+- For self-hosted, place the API behind HTTPS in production.
+
+## Reference
+
+- API v2 Reference: /docs/api-reference/v2
+- Differences v1 vs v2: /docs/api-reference/v2/v1-v2-differences
+


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new guide for using Cal.com API v2 in self-hosted (OSS) environments. It clarifies how to interact with the API, covering base URLs, authentication methods, API versioning, pagination, error handling, and provides practical cURL examples.

- Adds `docs/self-hosting/guides/api/using-api-v2.mdx`
- Updates `docs/mint.json` to include the new guide in the navigation under "Self Hosting > Guides > API".

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

![Screenshot of new API v2 OSS documentation page](https://github.com/calcom/cal.com/assets/users/your-username/your-image-link.png)
*(Replace `your-username` and `your-image-link.png` with an actual screenshot of the new page in the local docs)*

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A for documentation)

## How should this be tested?

- Run the documentation site locally.
- Navigate to `Self Hosting` -> `Guides` -> `API` in the sidebar.
- Verify that the "Using API v2 in Self-Hosted (OSS)" page loads correctly and displays the content as intended.
- Check that internal links to other API reference pages are functional.

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

---
<a href="https://cursor.com/background-agent?bcId=bc-4ea8b3fc-56d0-4de1-8790-243b1007d674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ea8b3fc-56d0-4de1-8790-243b1007d674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

